### PR TITLE
check if method exists before calling

### DIFF
--- a/lib/i18n_country_select/instance_tag.rb
+++ b/lib/i18n_country_select/instance_tag.rb
@@ -8,7 +8,7 @@ module I18nCountrySelect
 
     # Adapted from Rails country_select. Just uses country codes instead of full names.
     def country_code_select(priority_countries, options, html_options)
-      selected = object.send(@method_name)
+      selected = object.send(@method_name) if object.respond_to?(@method_name)
       
       country_translations = COUNTRY_CODES.map{|code| [I18n.t(code, :scope => :countries), code]}.sort_alphabetical_by(&:first)
 


### PR DESCRIPTION
The code breaks when used with fields_for without association, for example:

```
<%= fields_for :person do |permission_fields| %>
  Admin?: <%= permission_fields.check_box :admin %>
<% end %>
```

This is the fix for this issue.
