### PR TITLE
Allow using prio countries and include_blank in combination

### DIFF
--- a/lib/i18n_country_select/instance_tag.rb
+++ b/lib/i18n_country_select/instance_tag.rb
@@ -1,7 +1,7 @@
 module I18nCountrySelect
   module InstanceTag
     include Countries
-    
+
     def to_country_code_select_tag(priority_countries, options = {}, html_options = {})
       country_code_select(priority_countries, options, html_options)
     end
@@ -9,20 +9,23 @@ module I18nCountrySelect
     # Adapted from Rails country_select. Just uses country codes instead of full names.
     def country_code_select(priority_countries, options, html_options)
       selected = object.send(@method_name) if object.respond_to?(@method_name)
-      
+
       country_translations = COUNTRY_CODES.map{|code| [I18n.t(code, :scope => :countries), code]}.sort_alphabetical_by(&:first)
 
       countries = ""
+
+      if options[:include_blank]
+        option = options[:include_blank] == true ? "" : options[:include_blank]
+        countries += "<option value=\"\">#{option}</options>\n"
+      end
+
       if priority_countries
         countries += options_for_select(priority_countries, selected)
-        countries += "<option value=\"\" disabled=\"disabled\">-------------</option>\n"
-      elsif options[:include_blank]
-        countries += "<option value=\"\">" + options[:include_blank] + "</options>\n"
         countries += "<option value=\"\" disabled=\"disabled\">-------------</option>\n"
       end
 
       countries = countries + options_for_select(country_translations, selected)
-      
+
       html_options = html_options.stringify_keys
       add_default_name_and_id(html_options)
 

--- a/spec/integration/form_helpers_spec.rb
+++ b/spec/integration/form_helpers_spec.rb
@@ -5,13 +5,13 @@ describe "Form Helpers" do
     # TODO:
     # Get the translations get loaded. We need to get the app loaded so the translations will load
     # We can probably do something with fake_app for this purpose.
-    
+
     include I18nCountrySelect::FormHelpers
-    
+
     before(:each) do
       @user = mock("User", :country => nil)
     end
-    
+
     it "should output a select field with countries" do
       output = country_code_select(:user, :country)
       output.should match(/select id="user_country"/)
@@ -22,16 +22,26 @@ describe "Form Helpers" do
       output.should match(/option value="US"/)
     end
 
+    it "should output a select field with priority countries and include_blank line at the beginning" do
+      output = country_code_select(:user, :country, [ "US", 'United States' ], :include_blank => true)
+      output.should include('<select id="user_country" name="user[country]"><option value=""></options>')
+    end
+
+    it "should output a select field with priority countries and include_blank line with comment" do
+      output = country_code_select(:user, :country, [ "US", 'United States' ], :include_blank => "Choose..")
+      output.should include('<select id="user_country" name="user[country]"><option value="">Choose..</options>')
+    end
+
     it "should output a select field with passed attributes" do
       output = country_code_select(:user, :country, [ "US", "United States" ], {}, :class => "custom_class")
       output.should match(/select class="custom_class"/)
     end
-    
+
     it "should output a valid select field for fields_for nested attributes" do
       # no idea how to write the test for this.
       # output.should match /select id="user_shipping_address_attributes_country"/
     end
-    
+
     it "should not contain missing translations" do
       output = country_code_select(:user, :country, [ "US", "United States" ], {}, :class => "custom_class")
       output.should_not match(/translation missing/)


### PR DESCRIPTION
The current implementation allows only priority countries or include_blank to be active. This patch makes it possible to use both at the same time.
