### PR TITLE
Ignore missing translations from i18n-country-translations

### DIFF
--- a/lib/i18n_country_select/instance_tag.rb
+++ b/lib/i18n_country_select/instance_tag.rb
@@ -10,7 +10,10 @@ module I18nCountrySelect
     def country_code_select(priority_countries, options, html_options)
       selected = object.send(@method_name) if object.respond_to?(@method_name)
 
-      country_translations = COUNTRY_CODES.map{|code| [I18n.t(code, :scope => :countries), code]}.sort_alphabetical_by(&:first)
+      country_translations = country_translations = COUNTRY_CODES.map do |code|
+        translation = I18n.t(code, :scope => :countries, :default => 'missing')
+        translation == 'missing' ? nil : [translation, code]
+      end.compact.sort_alphabetical_by(&:first)
 
       countries = ""
 


### PR DESCRIPTION
Since available country codes seem to change quite a lot on CLDR and every one puts different country codes in the COUNTRY_CODES constant, I suggest we simply ignore missing translations to build the select.

This will also avoid breaking i18n_country_select between versions of  i18n-country-translations.

On the long term, It would probably be good to add a rake task to get the countries from CLDR to be in sync between the two gem? Or adding version dependencies between the gems?
