### PR TITLE
Blank option tag support for html5 placeholder

### DIFF
--- a/lib/i18n_country_select/instance_tag.rb
+++ b/lib/i18n_country_select/instance_tag.rb
@@ -19,7 +19,7 @@ module I18nCountrySelect
 
       if options[:include_blank]
         option = options[:include_blank] == true ? "" : options[:include_blank]
-        countries += "<option value=\"\">#{option}</option>\n"
+        countries += "<option>#{option}</option>\n"
       end
 
       if priority_countries


### PR DESCRIPTION
I removed the unnecessary value attribute and corrected a spelling error on the include_blank option tag.
