### PR TITLE
Changed call to ActionView::Helpers::InstanceTag to fix "uninitialized c...

### DIFF
--- a/lib/i18n_country_select.rb
+++ b/lib/i18n_country_select.rb
@@ -8,5 +8,5 @@ require "i18n_country_select/form_helpers"
 require "i18n_country_select/instance_tag"
 
 ActionView::Base.send(:include, I18nCountrySelect::FormHelpers)
-ActionView::Helpers::InstanceTag.send(:include, I18nCountrySelect::InstanceTag)
+ActionView::Helpers::ActiveModelInstanceTag.send(:include, I18nCountrySelect::InstanceTag)
 ActionView::Helpers::FormBuilder.send(:include, I18nCountrySelect::FormBuilder)


### PR DESCRIPTION
Changed call to ActionView::Helpers::InstanceTag to fix "uninitialized constant ActionView::Helpers::InstanceTag (NameError)" error with Rails 4
