### PR TITLE
Fixed options being ignored when running Rails 4.

### DIFF
--- a/lib/i18n_country_select/form_helpers.rb
+++ b/lib/i18n_country_select/form_helpers.rb
@@ -3,11 +3,11 @@ module I18nCountrySelect
     def country_code_select(object_name, method, priority_countries = nil, options = {}, html_options = {})
       if Rails::VERSION::MAJOR >= 4
         instance_tag = ActionView::Helpers::Tags::Select.new(object_name, method, self, [], options, html_options)
-        return instance_tag.to_country_code_select_tag(priority_countries, options.delete(:object), html_options)
-     else
-       instance_tag = ActionView::Helpers::InstanceTag.new(object_name, method, self, options.delete(:object))
-       return instance_tag.to_country_code_select_tag(priority_countries, options, html_options)
-     end
+        instance_tag.to_country_code_select_tag(priority_countries, html_options)
+      else
+        instance_tag = ActionView::Helpers::InstanceTag.new(object_name, method, self, options.delete(:object))
+        instance_tag.to_country_code_select_tag(priority_countries, html_options, options)
+      end
     end
   end
 end

--- a/lib/i18n_country_select/instance_tag.rb
+++ b/lib/i18n_country_select/instance_tag.rb
@@ -2,7 +2,11 @@ module I18nCountrySelect
   module InstanceTag
     include Countries
 
-    def to_country_code_select_tag(priority_countries, options = {}, html_options = {})
+    def to_country_code_select_tag(priority_countries, html_options = {}, options = {})
+      # Rails 4 stores options sent when creating an InstanceTag.
+      # Let's use them!
+      options = @options if defined?(@options)
+
       country_code_select(priority_countries, options, html_options)
     end
 


### PR DESCRIPTION
A #delete call should've been #except instead.
Anyway, we can do it even better by reusing @options variable set by Rails 4's ActiveModelInstanceTag.
