### PR TITLE
Fixed typo in README.rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -5,7 +5,7 @@
 
 A simple country code select helper with I18n translations for the countries. Works exactly the same as country_select but uses country codes instead and has i18n translations for the country names.
 
-NOTE: The old country_code_select repository that this one was forked from is outdated and no longer maintained. This i18_country_select repository is the most corrent.
+NOTE: The old country_code_select repository that this one was forked from is outdated and no longer maintained. This i18_country_select repository is the most current.
 
 == Requirements
 


### PR DESCRIPTION
"corrent" -> "current"

Thanks!