### PR TITLE
Add 'exclude' parameter, which excludes countries from the original list of countries

### DIFF
--- a/lib/i18n_country_select/instance_tag.rb
+++ b/lib/i18n_country_select/instance_tag.rb
@@ -24,7 +24,13 @@ module I18nCountrySelect
         countries += "<option value=\"\" disabled=\"disabled\">-------------</option>\n"
       end
 
-      countries = countries + options_for_select(country_translations, selected)
+      translations = if options[:exclude].present?
+                       country_translations.reject { |ct| options[:exclude].include? ct[1] }
+                     else
+                       country_translations
+                     end
+
+      countries = countries + options_for_select(translations, selected)
 
       html_options = html_options.stringify_keys
       add_default_name_and_id(html_options)

--- a/spec/integration/form_helpers_spec.rb
+++ b/spec/integration/form_helpers_spec.rb
@@ -34,6 +34,11 @@ describe "Form Helpers" do
       expect(output).to match(/select class="custom_class"/)
     end
 
+    it "should output countries except the ones in the exclude_countries parameter" do
+      output = country_code_select(:user, :country, [], exclude: [:US], :class => "custom_class")
+      expect(output).to_not include('<option value="US">United States</option>')
+    end
+
     it "should output a valid select field for fields_for nested attributes" do
       # no idea how to write the test for this.
       # output.should match /select id="user_shipping_address_attributes_country"/


### PR DESCRIPTION
Adding new 'exclude' parameter to the options hash for `country_code_select`, which allows excludes countries from the output.

Usage:

`country_code_select(:user, :country, [], exclude: [:US], :class => "custom_class")`
will exclude United States from the output.