### PR TITLE
relax dependency requirements, add rails 6.1 support

### DIFF
--- a/i18n_country_select.gemspec
+++ b/i18n_country_select.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.rubyforge_project = '[none]'
   s.required_rubygems_version = '>= 1.3.5'
-  s.add_dependency('i18n', '~> 0.9.3')
-  s.add_dependency('i18n-country-translations', '~> 1.0', '>= 1.3.0')
-  s.add_runtime_dependency 'unicode_utils', '~> 1.0', '>= 1.0.0'
+  s.add_dependency('i18n', '>= 0.5', '< 2.0')
+  s.add_dependency('i18n-country-translations', '~> 1.0', '>= 1.0.3')
+  s.add_runtime_dependency 'unicode_utils', '~> 1.0'
   s.add_development_dependency 'rails', '~> 4.0', '>= 4.0.0'
   s.add_development_dependency 'rspec-rails', '~> 3.5', '>= 3.5.2'
   s.licenses = ['MIT', 'GPL-3.0']


### PR DESCRIPTION
I18n country select dependency`i18n ~> 0.9.3` means this gem allows i18n versions `>= 0.9.3` and `< 1.0.0`
This makes it incompatible with rails 6.1, as they require `i18n >= 1.6`
I believe the intention should be just `>= 0.9.3`.

The gem does not actually depend on i18n being <1. There is a PR #33 that just changes the version. This suggests that the code works with i18n >1. The gemspec should allow that. 

Also, older country translations is also supported. They were upgraded in #30 because of security concerns, without any code changes. Bundler warns and advises for security. This gem should not force people to upgrade.